### PR TITLE
[LevelUP] Use agg backend for matplotlib to avoid cairo

### DIFF
--- a/levelup/levelup.py
+++ b/levelup/levelup.py
@@ -7,10 +7,13 @@ import random
 import typing
 import validators
 
+import matplotlib
+matplotlib.use("agg")
+import matplotlib.pyplot as plt
+plt.switch_backend("agg")
 
 import discord
 from discord.ext import tasks
-from matplotlib import pyplot as plt
 from redbot.core import commands, Config
 from redbot.core.utils.chat_formatting import box
 


### PR DESCRIPTION
This change avoids using cairo as a backend for matplotlib for the lset seelevels command. Cairo can be problematic or difficult to install on Windows devices and I try to avoid it as much as possible with graphics related cogs.