### PR TITLE
[LevelUP] Use aiohttp instead of requests

### DIFF
--- a/levelup/levelup.py
+++ b/levelup/levelup.py
@@ -7,13 +7,9 @@ import random
 import typing
 import validators
 
-import matplotlib
-matplotlib.use("agg")
-import matplotlib.pyplot as plt
-plt.switch_backend("agg")
-
 import discord
 from discord.ext import tasks
+from matplotlib import pyplot as plt
 from redbot.core import commands, Config
 from redbot.core.utils.chat_formatting import box
 

--- a/levelup/levelup.py
+++ b/levelup/levelup.py
@@ -111,25 +111,15 @@ class LevelUp(commands.Cog):
 
     # Generate rinky dink profile image
     async def gen_profile_img(self, args: dict):
-
-        def exe():
-            image = Generator().generate_profile(**args)
-            file = discord.File(fp=image, filename="image.png")
-            return file
-
-        profile = await self.bot.loop.run_in_executor(None, exe)
-        return profile
+        image = await Generator().generate_profile(**args)
+        file = discord.File(fp=image, filename=f"image_{random.randint(1000, 99999)}.png")
+        return file
 
     # Generate rinky dink level up image
     async def gen_levelup_img(self, args: dict):
-
-        def exe():
-            image = Generator().generate_levelup(**args)
-            file = discord.File(fp=image, filename="image.png")
-            return file
-
-        lvlup = await self.bot.loop.run_in_executor(None, exe)
-        return lvlup
+        image = await Generator().generate_levelup(**args)
+        file = discord.File(fp=image, filename=f"image_{random.randint(1000, 99999)}.png")
+        return file
 
     # Dump cache to config
     async def dump_cache(self):

--- a/levelup/levelup.py
+++ b/levelup/levelup.py
@@ -7,10 +7,13 @@ import random
 import typing
 import validators
 
+import matplotlib
+matplotlib.use("agg")
+import matplotlib.pyplot as plt
+plt.switch_backend("agg")
 
 import discord
 from discord.ext import tasks
-from matplotlib import pyplot as plt
 from redbot.core import commands, Config
 from redbot.core.utils.chat_formatting import box
 


### PR DESCRIPTION
I didn't leave the run in executor things in here because I was having trouble using it with an async function, but this is a good example of using aiohttp instead of requests.

I changed the filenames (added a random int to the generated file names) because if you have multiple generations happen in the same millisecond, sometimes 2x or more generated images can end up in the same final file, so might as well be safe. You could use a user id or another random int instead but I didn't want to modify the functions too much and a randint was the "easiest" thing to do there imo.