### PR TITLE
[LevelUp] Use WEBP instead of PNG

### DIFF
--- a/levelup/generator.py
+++ b/levelup/generator.py
@@ -178,7 +178,7 @@ class Generator:
 
         final = Image.alpha_composite(pre, blank)
         final_bytes = BytesIO()
-        final.save(final_bytes, 'png')
+        final.save(final_bytes, 'WEBP')
         final_bytes.seek(0)
         return final_bytes
 
@@ -238,7 +238,7 @@ class Generator:
 
         final = Image.alpha_composite(pre, blank)
         final_bytes = BytesIO()
-        final.save(final_bytes, 'png')
+        final.save(final_bytes, 'WEBP')
         final_bytes.seek(0)
         return final_bytes
 

--- a/levelup/levelup.py
+++ b/levelup/levelup.py
@@ -122,13 +122,13 @@ class LevelUp(commands.Cog):
     # Generate rinky dink profile image
     async def gen_profile_img(self, args: dict):
         image = await Generator().generate_profile(**args)
-        file = discord.File(fp=image, filename=f"image_{random.randint(1000, 99999)}.png")
+        file = discord.File(fp=image, filename=f"image_{random.randint(1000, 99999)}.webp")
         return file
 
     # Generate rinky dink level up image
     async def gen_levelup_img(self, args: dict):
         image = await Generator().generate_levelup(**args)
-        file = discord.File(fp=image, filename=f"image_{random.randint(1000, 99999)}.png")
+        file = discord.File(fp=image, filename=f"image_{random.randint(1000, 99999)}.webp")
         return file
 
     # Dump cache to config


### PR DESCRIPTION
Profile images were about 400kb with png and about 45kb with webp. This isn't a massive difference considering your profile pics are pretty small to begin with but good for people on slow connections or other data/speed related issues.