### PR TITLE
Typo fix for ignoreguild

### DIFF
--- a/emojitracker/emojitracker.py
+++ b/emojitracker/emojitracker.py
@@ -94,7 +94,7 @@ class EmojiTracker(commands.Cog):
             else:
                 users[uid][emoji] += 1
 
-    @commands.command(name="ingoreguild")
+    @commands.command(name="ignoreguild")
     @commands.is_owner()
     async def blacklist_guild(self, ctx, guild_id: int):
         """


### PR DESCRIPTION
Fixes a typo in the ignoreguild command. I tested via patch of my fork and it worked nicely.