### PR TITLE
Fix category_id to channel_id

### DIFF
--- a/tickets/commands.py
+++ b/tickets/commands.py
@@ -37,7 +37,7 @@ class TicketCommands(commands.Cog):
             inline=False
         )
         step2 = _("Set the channel that the bots ticket panel will be located in.\n")
-        step2 += f"`{ctx.prefix}tickets setchannel " + _("<panel_name> <category_id>`")
+        step2 += f"`{ctx.prefix}tickets setchannel " + _("<panel_name> <channel_id>`")
         em.add_field(
             name=_("Step 2"),
             value=step2,


### PR DESCRIPTION
Step 2 requires a channel ID but the command example asks for <category_id>