### PR TITLE
[LevelUp] Add `mypf` toggle for profile background blur

### DIFF
--- a/levelup/abc.py
+++ b/levelup/abc.py
@@ -75,6 +75,7 @@ class MixinMeta(ABC):
         role_icon: str = None,
         font_name: str = None,
         render_gifs: bool = False,
+        blur: bool = False,
     ):
         raise NotImplementedError
 

--- a/levelup/generator.py
+++ b/levelup/generator.py
@@ -43,6 +43,7 @@ class Generator(MixinMeta, ABC):
         role_icon: str = None,
         font_name: str = None,
         render_gifs: bool = False,
+        blur: bool = False,
     ):
         # get profile pic
         if profile_image:
@@ -167,9 +168,10 @@ class Generator(MixinMeta, ABC):
         blank.paste(transparent_box, (bar_start - 20, 0))
 
         # Make the semi-transparent box area blurry
-        blurred = card.filter(ImageFilter.GaussianBlur(3))
-        blurred = blurred.crop(((bar_start - 20), 0, card.size[0], card.size[1]))
-        card.paste(blurred, (bar_start - 20, 0), blurred)
+        if blur:
+            blurred = card.filter(ImageFilter.GaussianBlur(3))
+            blurred = blurred.crop(((bar_start - 20), 0, card.size[0], card.size[1]))
+            card.paste(blurred, (bar_start - 20, 0), blurred)
         final = Image.alpha_composite(card, blank)
 
         # Make the level progress bar
@@ -523,6 +525,7 @@ class Generator(MixinMeta, ABC):
         role_icon: str = None,
         font_name: str = None,
         render_gifs: bool = False,
+        blur: bool = False,
     ):
         # Colors
         base = self.rand_rgb()
@@ -606,6 +609,12 @@ class Generator(MixinMeta, ABC):
         blank = Image.new("RGBA", card.size, (255, 255, 255, 0))
         transparent_box = Image.new("RGBA", card.size, (0, 0, 0, 100))
         blank.paste(transparent_box, (240, 0))
+
+        # Make the semi-transparent box area blurry
+        if blur:
+            blurred = card.filter(ImageFilter.GaussianBlur(3))
+            blurred = blurred.crop((240, 0, card.size[0], card.size[1]))
+            card.paste(blurred, (240, 0), blurred)
         card = Image.alpha_composite(card, blank)
 
         # Draw

--- a/levelup/generator.py
+++ b/levelup/generator.py
@@ -8,7 +8,7 @@ from typing import Union
 
 import colorgram
 import requests
-from PIL import Image, ImageDraw, ImageFont, UnidentifiedImageError
+from PIL import Image, ImageDraw, ImageFont, UnidentifiedImageError, ImageFilter
 from redbot.core.i18n import Translator, cog_i18n
 from redbot.core.utils.chat_formatting import humanize_number
 
@@ -165,6 +165,11 @@ class Generator(MixinMeta, ABC):
         blank = Image.new("RGBA", card.size, (255, 255, 255, 0))
         transparent_box = Image.new("RGBA", card.size, (0, 0, 0, 100))
         blank.paste(transparent_box, (bar_start - 20, 0))
+
+        # Make the semi-transparent box area blurry
+        blurred = card.filter(ImageFilter.GaussianBlur(3))
+        blurred = blurred.crop(((bar_start - 20), 0, card.size[0], card.size[1]))
+        card.paste(blurred, (bar_start - 20, 0), blurred)
         final = Image.alpha_composite(card, blank)
 
         # Make the level progress bar

--- a/levelup/levelup.py
+++ b/levelup/levelup.py
@@ -450,6 +450,9 @@ class LevelUp(UserCommands, Generator, commands.Cog, metaclass=CompositeMetaClas
             if "font" not in user:
                 conf["users"][uid]["font"] = None
                 cleaned.append("font not in user")
+            if "blur" not in user:
+                conf["users"][uid]["blur"] = False
+                cleaned.append("blur not in user")
 
             # Make sure all related stats are not strings
             for k, v in user.items():
@@ -516,6 +519,7 @@ class LevelUp(UserCommands, Generator, commands.Cog, metaclass=CompositeMetaClas
             "full": True,
             "colors": {"name": None, "stat": None, "levelbar": None},
             "font": None,
+            "blur": False,
         }
 
     def init_user_weekly(self, guild_id: int, user_id: str):


### PR DESCRIPTION
This PR adds a toggle to `mypf` that lets a user add a slight blur effect to the right side of their profile card, under the transparent box, to make the text a bit easier to read on busier backgrounds.
It is off by default.

I have tested the PR on a bot with no data and on a bot with production data, seems to work fine.