### PR TITLE
Update the roles of individual users through `[p]lvlset roles initialize`

### DIFF
--- a/levelup/main.py
+++ b/levelup/main.py
@@ -75,7 +75,7 @@ class LevelUp(
     """
 
     __author__ = "[vertyco](https://github.com/vertyco/vrt-cogs)"
-    __version__ = "4.2.4"
+    __version__ = "4.2.5"
     __contributors__ = [
         "[aikaterna](https://github.com/aikaterna/aikaterna-cogs)",
         "[AAA3A](https://github.com/AAA3A-AAA3A/AAA3A-cogs)",


### PR DESCRIPTION
This pull request adds a `target` argument to the `[p]levelset roles initialize` command, allowing a server administrator to sync a specific users' level roles.
This functionality is complete and works, the reason this PR is currently marked as a draft is because of the guild cooldown on this command. I think the cooldown should only be enforced if the `target` argument isn't provided, as updating a single user probably isn't a very expensive operation, compared to updating the entire server.
However, I wanted to get others' opinions on this before changing it as it is a different change.