### PR TITLE
Remove gpt-4-vision-preview from models list due to deprecation

### DIFF
--- a/assistant/common/constants.py
+++ b/assistant/common/constants.py
@@ -12,7 +12,7 @@ MODELS = {
     "gpt-4-turbo-preview": 128000,
     "gpt-4-1106-preview": 128000,
     "gpt-4-0125-preview": 128000,
-    "gpt-4-vision-preview": 128000,
+    # "gpt-4-vision-preview": 128000, - Depricated
     "gpt-4-turbo-2024-04-09": 128000,
     "gpt-4o": 128000,
     "gpt-4o-2024-05-13": 128000,


### PR DESCRIPTION
gpt-4-vision-preview causes the bot to throw the following error:
`openai.NotFoundError: Error code: 404 - {'error': {'message': 'The model `gpt-4-vision-preview` has been deprecated, learn more here: https://platform.openai.com/docs/deprecations', 'type': 'invalid_request_error', 'param': None, 'code': 'model_not_found'}}`
Looks like gpt-4-vision-preview has now been deprecated as per the [OpenAI docs site](https://platform.openai.com/docs/deprecations#2024-06-06-gpt-4-32k-and-vision-preview-models)

This PR removes the model from the models list