### PR TITLE
[Assistant] Fix exception when a tutor role is deleted

### DIFF
--- a/assistant/assistant.py
+++ b/assistant/assistant.py
@@ -54,7 +54,7 @@ class Assistant(
     """
 
     __author__ = "[vertyco](https://github.com/vertyco/vrt-cogs)"
-    __version__ = "6.11.2"
+    __version__ = "6.11.3"
 
     def format_help_for_context(self, ctx):
         helpcmd = super().format_help_for_context(ctx)

--- a/assistant/commands/admin.py
+++ b/assistant/commands/admin.py
@@ -148,7 +148,7 @@ class Admin(MixinMeta):
             inline=False,
         )
         tutors = [ctx.guild.get_member(i) or ctx.guild.get_role(i) for i in conf.tutors]
-        mentions = [i.mention for i in tutors]
+        mentions = [i.mention for i in tutors if i]
         tutor_field = _(
             "The following roles/users are considered tutors. "
             "If function calls are on and create_memory is enabled, the model can create its own embeddings: "


### PR DESCRIPTION
Fixes an exception in `assistant view` that happens after a tutor role gets deleted