### PR TITLE
[LevelUp] Extend external API and add dynamic command cooldown and unlocking based on level

### DIFF
--- a/levelup/common/models.py
+++ b/levelup/common/models.py
@@ -281,6 +281,13 @@ class GuildSettings(Base):
     cooldown: int = 60  # Only gives XP every 60 seconds
     min_length: int = 0  # Minimum length of message to be considered eligible for XP gain
 
+    # command checks and cooldown based on level
+    cmd_requirements: t.Dict[str, int] = {}  # command name -> level requirement
+    # command name -> Dict[level, cooldown], levels at specified level and under will be under that cooldown
+    cmd_cooldowns: t.Dict[str, t.Dict[int, int]] = {}
+    cmd_bypass_roles: t.List[int] = []  # allow roles to bypass req level and cooldown
+    cmd_bypass_member: t.List[int] = []  # allow members to bypass req level and cooldown
+
     # Voice
     voicexp: int = 2  # XP per minute in voice
     ignore_muted: bool = True  # Ignore XP while being muted in voice

--- a/levelup/main.py
+++ b/levelup/main.py
@@ -131,6 +131,8 @@ class LevelUp(
 
     async def cog_unload(self) -> None:
         self.bot.tree.remove_command(view_profile_context)
+        self.bot.remove_before_invoke_hook(self.level_check)
+        self.bot.remove_before_invoke_hook(self.cooldown_check)
         self.stop_levelup_tasks()
 
     async def start_api(self) -> bool:
@@ -244,6 +246,10 @@ class LevelUp(
 
         if voice_initialized := await self.initialize_voice_states():
             log.info(f"Initialized {voice_initialized} voice states")
+
+        # add checks
+        self.bot.before_invoke(self.level_check)
+        self.bot.before_invoke(self.cooldown_check)
 
         self.start_levelup_tasks()
         self.custom_fonts.mkdir(exist_ok=True)

--- a/levelup/shared/__init__.py
+++ b/levelup/shared/__init__.py
@@ -2,9 +2,10 @@ from ..abc import CompositeMetaClass
 from .levelups import LevelUps
 from .profile import ProfileFormatting
 from .weeklyreset import WeeklyReset
+from .checks import Checks
 
 
-class SharedFunctions(LevelUps, ProfileFormatting, WeeklyReset, metaclass=CompositeMetaClass):
+class SharedFunctions(LevelUps, ProfileFormatting, WeeklyReset, Checks, metaclass=CompositeMetaClass):
     """
     Subclass all shared metaclassed parts of the cog
 

--- a/levelup/shared/checks.py
+++ b/levelup/shared/checks.py
@@ -1,0 +1,92 @@
+import logging
+import bisect
+import typing as t
+
+import discord
+from redbot.core.i18n import Translator
+from redbot.core.utils.chat_formatting import warning
+from redbot.core import commands
+
+from ..abc import MixinMeta
+
+log = logging.getLogger("red.vrt.levelup.shared.checks")
+_ = Translator("LevelUp", __file__)
+
+
+class Checks(MixinMeta):
+    def __init__(self):
+        self.last_invoked: t.Dict[t.Tuple[int, str], float] = {}  # (member id, command) -> last usage time
+
+    async def level_check(self, ctx: commands.Context) -> bool:
+        if not ctx.guild:
+            return True
+        member = ctx.author
+        if isinstance(member, discord.User):
+            return True
+        conf = self.db.get_conf(member.guild)
+        command = ctx.command.qualified_name
+        if command not in conf.cmd_requirements:
+            return True
+
+        # allow help command
+        if ctx.command.name == "help" or ctx.invoked_with == "help":
+            return True
+
+        # check bypasses
+        bypass_roles = set([r.id for r in member.roles]) & set(conf.cmd_bypass_roles)
+        if member.id in conf.cmd_bypass_member or len(bypass_roles) >= 1:
+            return True
+
+        profile = conf.get_profile(member)
+        level = profile.level
+        req_level = conf.cmd_requirements[command]
+        if level < req_level:
+            await ctx.reply(
+                warning(f"You need level `{req_level}` to use `{ctx.command}`. (current level: {level})"),
+                delete_after=30,
+                mention_author=False,
+            )
+            raise commands.CheckFailure()
+        return True
+
+    async def cooldown_check(self, ctx: commands.Context) -> bool:
+        if not ctx.guild:
+            return True
+        member = ctx.author
+        if isinstance(member, discord.User):
+            return True
+        conf = self.db.get_conf(member.guild)
+        command = ctx.command.qualified_name
+        if command not in conf.cmd_cooldowns:
+            return True
+
+        # check bypasses
+        bypass_roles = set([r.id for r in member.roles]) & set(conf.cmd_bypass_roles)
+        if member.id in conf.cmd_bypass_member or len(bypass_roles) >= 1:
+            return True
+
+        cooldowns = conf.cmd_cooldowns[command]
+        levels = sorted(cooldowns.keys())
+        profile = conf.get_profile(member)
+        level = profile.level
+
+        cooldown_level = bisect.bisect_left(levels, level)
+        if cooldown_level == len(
+            levels
+        ):  # user has a higher level then all of the specified cooldowns, so no cooldown is applied
+            return True
+        cooldown = cooldowns[levels[cooldown_level]]
+
+        key = (member.id, command)
+        now = ctx.message.created_at.timestamp()
+        last = self.last_invoked.get(key, 0)
+        retry_after = last + cooldown - now
+
+        if retry_after > 0:
+            bucket_cooldown = commands.Cooldown(1, cooldown)
+            raise commands.CommandOnCooldown(bucket_cooldown, retry_after, commands.BucketType.member)
+        self.last_invoked[key] = now
+        # override any built in cooldowns for the command
+        ctx.command.reset_cooldown(ctx)
+
+        return True

--- a/levelup/shared/profile.py
+++ b/levelup/shared/profile.py
@@ -52,6 +52,22 @@ class ProfileFormatting(MixinMeta):
         self.save()
         return int(profile.xp)
 
+    async def get_xp(self, member: discord.Member) -> int:
+        """Get the XP for a member"""
+        if not isinstance(member, discord.Member):
+            raise TypeError("member must be a discord.Member")
+        conf = self.db.get_conf(member.guild)
+        profile = conf.get_profile(member)
+        return int(profile.xp)
+
+    async def get_level(self, member: discord.Member) -> int:
+        """Get the level for a member"""
+        if not isinstance(member, discord.Member):
+            raise TypeError("member must be a discord.Member")
+        conf = self.db.get_conf(member.guild)
+        profile = conf.get_profile(member)
+        return profile.level
+
     async def get_profile_background(
         self, user_id: int, profile: Profile, try_return_url: bool = False
     ) -> t.Union[bytes, str]:
@@ -108,7 +124,9 @@ class ProfileFormatting(MixinMeta):
             return f"https://cdn.discordapp.com/banners/{user_id}/{banner_id}?size=1024"
 
     async def get_user_profile(
-        self, member: discord.Member, reraise: bool = False
+        self,
+        member: discord.Member,
+        reraise: bool = False,
     ) -> t.Union[discord.Embed, discord.File]:
         """
         Get a user's profile as an embed or file


### PR DESCRIPTION
I extended the functionality of the shared functions for user profiles, allowing external cogs to get xp and level of users. I also added a new system to LevelUp that allows guild owners to setup dynamic command lock/unlock based on their level, as well as cooldowns for any command based on level. This is done by creating hooks and injecting them into RedBot that will check user's level and send appropriate error messages if they do not meet the level requirement for a command, or are on cooldown for a command based on their level.