### PR TITLE
Update quickpull command to stop reimplementing Downloader (+ 3.5.25 support)

### DIFF
--- a/vrtutils/__init__.py
+++ b/vrtutils/__init__.py
@@ -2,6 +2,7 @@ from redbot.core.bot import Red
 from redbot.core.utils import get_end_user_data_statement
 
 from .commands.todo import mock_edit_message
+from .commands.updates import monkeypatch_repo, revert_monkeypatch_repo
 from .vrtutils import VrtUtils
 
 __red_end_user_data_statement__ = get_end_user_data_statement(__file__)
@@ -10,7 +11,9 @@ __red_end_user_data_statement__ = get_end_user_data_statement(__file__)
 async def setup(bot: Red):
     await bot.add_cog(VrtUtils(bot))
     bot.tree.add_command(mock_edit_message)
+    monkeypatch_repo()
 
 
 async def teardown(bot: Red):
     bot.tree.remove_command(mock_edit_message)
+    revert_monkeypatch_repo()

--- a/vrtutils/commands/updates.py
+++ b/vrtutils/commands/updates.py
@@ -9,7 +9,6 @@ from redbot.core import commands
 
 from ..abc import MixinMeta
 
-
 _ORIG_FUNC = None
 _INSTALL_REQS_VAR = contextvars.ContextVar("_INSTALL_REQS_VAR")
 

--- a/vrtutils/commands/updates.py
+++ b/vrtutils/commands/updates.py
@@ -1,19 +1,51 @@
+import contextvars
+import inspect
 import typing as t
+from pathlib import Path
 
+from redbot import VersionInfo, version_info
 from redbot.cogs.downloader.converters import InstalledCog
 from redbot.core import commands
-from redbot.core.utils.chat_formatting import humanize_list, inline
 
 from ..abc import MixinMeta
 
-DEPRECATION_NOTICE = (
-    "\n**WARNING:** The following repos are using shared libraries"
-    " which are marked for removal in the future: {repo_list}.\n"
-    " You should inform maintainers of these repos about this message."
-)
 
-# Code pulled from core Downloader cog
-# https://github.com/Cog-Creators/Red-DiscordBot/blob/V3/develop/redbot/cogs/downloader/downloader.py
+_ORIG_FUNC = None
+_INSTALL_REQS_VAR = contextvars.ContextVar("_INSTALL_REQS_VAR")
+
+
+async def install_raw_requirements(
+    self, requirements: t.Iterable[str], target_dir: Path
+) -> bool:
+    if _INSTALL_REQS_VAR.get(True):
+        return await _ORIG_FUNC(self, requirements, target_dir)
+    return True
+
+
+def _get_repo_manager_module() -> t.Any:
+    if version_info >= VersionInfo.from_str("3.5.25.dev7"):
+        from redbot.core._downloader import repo_manager
+    else:
+        from redbot.cogs.downloader import repo_manager
+
+    return repo_manager
+
+
+def monkeypatch_repo() -> None:
+    repo_manager = _get_repo_manager_module()
+    if inspect.getmodule(repo_manager.Repo.install_raw_requirements) is repo_manager:
+        global _ORIG_FUNC
+        _ORIG_FUNC = repo_manager.Repo.install_raw_requirements
+
+        setattr(repo_manager.Repo, "install_raw_requirements", install_raw_requirements)
+
+
+def revert_monkeypatch_repo() -> None:
+    repo_manager = _get_repo_manager_module()
+    global _ORIG_FUNC
+    if _ORIG_FUNC is not None:
+        setattr(repo_manager.Repo, "install_raw_requirements", _ORIG_FUNC)
+        _ORIG_FUNC = None
 
 
 class Updates(MixinMeta):
@@ -32,121 +64,15 @@ class Updates(MixinMeta):
     @commands.is_owner()
     async def quick_update_cog(self, ctx: commands.Context, *cogs: InstalledCog):
         """Auto update & reload cogs WITHOUT updating dependencies"""
-        cog = ctx.bot.get_cog("Downloader")
-        if cog is None:
+        ctx.assume_yes = True
+        cog_update_command = ctx.bot.get_command("cog update")
+        if cog_update_command is None:
             return await ctx.send(
                 f"Make sure you first `{ctx.clean_prefix}load downloader` before you can use this command."
             )
-        failed_repos = set()
-        updates_available = set()
 
-        async with ctx.typing():
-            cogs_to_check, check_failed = await cog._get_cogs_to_check(repos=None, cogs=cogs)
-            failed_repos.update(check_failed)
-
-            pinned_cogs = {cog for cog in cogs_to_check if cog.pinned}
-            cogs_to_check -= pinned_cogs
-
-            message = ""
-            if not cogs_to_check:
-                cogs_to_update = libs_to_update = ()
-                message += "There were no cogs to check."
-                if pinned_cogs:
-                    cognames = [cog.name for cog in pinned_cogs]
-                    message += (
-                        "\nThese cogs are pinned and therefore weren't checked: "
-                        if len(cognames) > 1
-                        else "\nThis cog is pinned and therefore wasn't checked: "
-                    ) + humanize_list(tuple(map(inline, cognames)))
-            else:
-                cogs_to_update, libs_to_update = await cog._available_updates(cogs_to_check)
-
-                updates_available = cogs_to_update or libs_to_update
-                cogs_to_update, filter_message = cog._filter_incorrect_cogs(cogs_to_update)
-
-                if updates_available:
-                    updated_cognames, message = await self._update_cogs_and_libs(
-                        ctx, cogs_to_update, current_cog_versions=cogs_to_check
-                    )
-                else:
-                    if cogs:
-                        message += "Provided cogs are already up to date."
-                    else:
-                        message += "All installed cogs are already up to date."
-                if pinned_cogs:
-                    cognames = [cog.name for cog in pinned_cogs]
-                    message += (
-                        "\nThese cogs are pinned and therefore weren't checked: "
-                        if len(cognames) > 1
-                        else "\nThis cog is pinned and therefore wasn't checked: "
-                    ) + humanize_list(tuple(map(inline, cognames)))
-                message += filter_message
-
-            if failed_repos:
-                message += "\n" + cog.format_failed_repos(failed_repos)
-
-            repos_with_libs = {
-                inline(module.repo.name)
-                for module in cogs_to_update + libs_to_update
-                if module.repo.available_libraries
-            }
-            if repos_with_libs:
-                message += DEPRECATION_NOTICE.format(repo_list=humanize_list(list(repos_with_libs)))
-
-            await cog.send_pagified(ctx, message)
-
-            if updates_available and updated_cognames:
-                ctx.assume_yes = True
-                await cog._ask_for_cog_reload(ctx, updated_cognames)
-
-    async def _update_cogs_and_libs(
-        self, ctx: commands.Context, cogs_to_update: list, current_cog_versions: list
-    ) -> t.Tuple[t.Set[str], str]:
-        current_cog_versions_map = {cog.name: cog for cog in current_cog_versions}
-
-        cog = ctx.bot.get_cog("Downloader")
-        installed_cogs, failed_cogs = await cog._install_cogs(cogs_to_update)
-        await cog._save_to_installed(installed_cogs)
-        message = "Cog update completed successfully."
-
-        updated_cognames: t.Set[str] = set()
-        if installed_cogs:
-            updated_cognames = set()
-            cogs_with_changed_eud_statement = set()
-            for cog in installed_cogs:
-                updated_cognames.add(cog.name)
-                current_eud_statement = current_cog_versions_map[cog.name].end_user_data_statement
-                if current_eud_statement != cog.end_user_data_statement:
-                    cogs_with_changed_eud_statement.add(cog.name)
-            message += "\nUpdated: " + humanize_list(tuple(map(inline, updated_cognames)))
-            if cogs_with_changed_eud_statement:
-                if len(cogs_with_changed_eud_statement) > 1:
-                    message += (
-                        "\nEnd user data statements of these cogs have changed: "
-                        + humanize_list(tuple(map(inline, cogs_with_changed_eud_statement)))
-                        + "\nYou can use {command} to see the updated statements.\n".format(
-                            command=inline(f"{ctx.clean_prefix}cog info <repo> <cog>")
-                        )
-                    )
-                else:
-                    message += (
-                        "\nEnd user data statement of this cog has changed:"
-                        + inline(next(iter(cogs_with_changed_eud_statement)))
-                        + "\nYou can use {command} to see the updated statement.\n".format(
-                            command=inline(f"{ctx.clean_prefix}cog info <repo> <cog>")
-                        )
-                    )
-            # If the bot has any slash commands enabled, warn them to sync
-            enabled_slash = await self.bot.list_enabled_app_commands()
-            if any(enabled_slash.values()):
-                message += "\nYou may need to resync your slash commands with `{prefix}slash sync`.".format(
-                    prefix=ctx.prefix
-                )
-        if failed_cogs:
-            cognames = [cog.name for cog in failed_cogs]
-            message += (
-                "\nFailed to update cogs: " if len(failed_cogs) > 1 else "\nFailed to update cog: "
-            ) + humanize_list(tuple(map(inline, cognames)))
-        if not cogs_to_update:
-            message = "No cogs were updated."
-        return (updated_cognames, message)
+        token = _INSTALL_REQS_VAR.set(False)
+        try:
+            await ctx.invoke(cog_update_command, *cogs)
+        finally:
+            _INSTALL_REQS_VAR.reset(token)

--- a/vrtutils/commands/updates.py
+++ b/vrtutils/commands/updates.py
@@ -63,7 +63,6 @@ class Updates(MixinMeta):
     @commands.is_owner()
     async def quick_update_cog(self, ctx: commands.Context, *cogs: InstalledCog):
         """Auto update & reload cogs WITHOUT updating dependencies"""
-        ctx.assume_yes = True
         cog_update_command = ctx.bot.get_command("cog update")
         if cog_update_command is None:
             return await ctx.send(
@@ -72,6 +71,6 @@ class Updates(MixinMeta):
 
         token = _INSTALL_REQS_VAR.set(False)
         try:
-            await ctx.invoke(cog_update_command, *cogs)
+            await ctx.invoke(cog_update_command, True, *cogs)
         finally:
             _INSTALL_REQS_VAR.reset(token)


### PR DESCRIPTION
This PR fixes the incoming incompatibility with https://github.com/Cog-Creators/Red-DiscordBot/pull/6706#pullrequestreview-4027217820 *and* it greatly simplifies the code by just calling `cog update` directly instead of reimplementing its logic.