### PR TITLE
Tickets - credit first responder on owner self-close

### DIFF
--- a/tickets/common/analytics.py
+++ b/tickets/common/analytics.py
@@ -187,9 +187,18 @@ def record_ticket_closed(
         )
     )
 
-    # --- Staff Stats (only if a staff member closed it, not self-close) ---
+    # --- Staff Stats ---
+    # If a staff member closed it, they get the credit.
+    # On a self-close by the owner, fall back to the attributed staff member
+    # (claimer, or first responder) so they still receive close credit.
+    staff_credit_id: int | None = None
     if closed_by_id != owner_id:
-        staff_stats = conf.get_staff_stats(closed_by_id)
+        staff_credit_id = closed_by_id
+    elif ticket.claimed_by is not None and ticket.claimed_by != owner_id:
+        staff_credit_id = ticket.claimed_by
+
+    if staff_credit_id is not None:
+        staff_stats = conf.get_staff_stats(staff_credit_id)
         staff_stats.tickets_closed += 1
         staff_stats.total_resolution_time += resolution_time
         staff_stats.resolution_count += 1


### PR DESCRIPTION
When a ticket owner closed their own ticket, record_ticket_closed
skipped the staff stats block entirely, so the assigned/first-responding
staff member never received tickets_closed credit, resolution time, or
a TICKET_CLOSED event. The function already attributes ticket.claimed_by
to the first responder when no explicit claimer exists, so route close
credit to that staff member on self-close.

https://claude.ai/code/session_01PcnLXE9Ek2Yu6tChjDp3Vc