### PR TITLE
fix(assistant): handle gif URLs breaking vision responses

### DIFF
--- a/assistant/CHANGELOG.md
+++ b/assistant/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Assistant Changelog
 
+## v8.18.3
+
+- **Fix**: A gif URL in a message no longer breaks the response. Gif URLs were matched and sent to the vision API, which returned a 400 `Error while downloading ...gif` (the API can't process animated gifs). Excluded gif from the image URL regex to match the attachment handler (which already skipped gif), and the `BadRequestError` handler now also strips images and retries on `Error while downloading` so any unfetchable image URL degrades gracefully instead of failing the whole reply.
+
 ## v8.18.2
 
 - **Fix**: `[p]assistant backup` no longer wipes live conversations. It excluded conversation data by clearing `self.db.conversations` on the real in-memory store; with per-file persistence that also caused the on-disk files to be overwritten on next use. Now excludes conversations from the dump non-destructively via `model_dump_json(exclude=...)`.

--- a/assistant/common/chat.py
+++ b/assistant/common/chat.py
@@ -567,7 +567,10 @@ class ChatHandler(MixinMeta):
         outputfile_pattern = r"--outputfile\s+([^\s]+)"
         extract_pattern = r"--extract"
         get_last_message_pattern = r"--last"
-        image_url_pattern = r"(https?:\/\/\S+\.(?:png|gif|webp|jpg|jpeg)(?:\?\S*)?)"
+        # NOTE: gif is intentionally excluded. The vision API cannot process (animated) gifs and
+        # responds with a 400 "Error while downloading" which breaks the response. This mirrors the
+        # attachment handling below which also excludes gif.
+        image_url_pattern = r"(https?:\/\/\S+\.(?:png|webp|jpg|jpeg)(?:\?\S*)?)"
 
         # Extract the optional arguments and their values
         outputfile_match = re.search(outputfile_pattern, question)
@@ -1054,7 +1057,10 @@ class ChatHandler(MixinMeta):
                     continue
                 raise e
             except openai.BadRequestError as e:
-                if "Invalid image" in str(e):
+                err_text = str(e)
+                # Some image URLs (e.g. gifs, or links the API can't fetch) cause a 400. Rather than
+                # failing the whole response, strip images from the payload and retry without them.
+                if "Invalid image" in err_text or "Error while downloading" in err_text:
                     await purge_images(messages)
                     tries += 1
                     continue


### PR DESCRIPTION
## Problem

When a message contained a GIF URL (e.g. `Mirosbird.gif`), the bot failed the entire response with:

> `Bad Request Error2(400): Error while downloading Mirosbird.gif`

## Root cause

The image URL regex in `assistant/common/chat.py` included `gif`, so gif URLs were forwarded to the vision API. OpenAI's vision can't process (animated) gifs and returns a 400 `Error while downloading`. The attachment handler right below it already excluded gif (`img_ext = ["png", "jpg", "jpeg", "webp"]`), so the two paths were inconsistent.

Additionally, the `BadRequestError` handler only retried-without-images on `"Invalid image"`, not `"Error while downloading"`, so this error fell through and broke the whole reply.

## Fix

1. Removed `gif` from the image URL regex so gif URLs are no longer sent to the vision API, matching the attachment handler.
2. The `BadRequestError` handler now also strips images and retries on `"Error while downloading"`, so any unfetchable image URL degrades gracefully (text answer still returned) instead of failing the entire response.

`purge_images()` already removes URL-sourced images, so the retry path works correctly.

Bumped changelog to `v8.18.3`.

---
_Generated by [Claude Code](https://claude.ai/code/session_011vjHtN5hcQi9hGonuDbMEG)_