### PR TITLE
feat(levelup): add command to update prestige level emoji

### DIFF
--- a/levelup/commands/admin.py
+++ b/levelup/commands/admin.py
@@ -1729,6 +1729,25 @@ class Admin(MixinMeta):
         self.save()
         await ctx.send(_("Role and emoji have been set for prestige level {}").format(prestige))
 
+    @prestige_group.command(name="emoji")
+    async def edit_prestige_emoji(
+        self,
+        ctx: commands.Context,
+        prestige: int,
+        emoji: t.Union[discord.Emoji, discord.PartialEmoji, str],
+    ):
+        """
+        Update the emoji for an existing prestige level
+        """
+        conf = self.db.get_conf(ctx.guild)
+        if prestige not in conf.prestigedata:
+            return await ctx.send(_("That prestige level does not exist!"))
+        url = utils.get_twemoji(emoji) if isinstance(emoji, str) else emoji.url
+        conf.prestigedata[prestige].emoji_string = str(emoji)
+        conf.prestigedata[prestige].emoji_url = url
+        self.save()
+        await ctx.send(_("Emoji has been updated for prestige level {}").format(prestige))
+
     @prestige_group.command(name="remove", aliases=["rem", "del"])
     async def remove_prestige_level(self, ctx: commands.Context, prestige: int):
         """

--- a/levelup/main.py
+++ b/levelup/main.py
@@ -80,7 +80,7 @@ class LevelUp(
     """
 
     __author__ = "[vertyco](https://github.com/vertyco/vrt-cogs)"
-    __version__ = "5.2.6"
+    __version__ = "5.2.7"
     __contributors__ = [
         "[aikaterna](https://github.com/aikaterna/aikaterna-cogs)",
         "[AAA3A](https://github.com/AAA3A-AAA3A/AAA3A-cogs)",


### PR DESCRIPTION
Add [p]levelset prestige emoji <level> <emoji> to update the emoji of an
existing prestige level in place, instead of having to remove and
re-create the level.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_016nUXaNwKUjaJM3zgzgmUNu